### PR TITLE
Ajuste cedulas inserir dinheiro

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/PapelMoeda.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/PapelMoeda.java
@@ -1,4 +1,4 @@
-package br.calebe.ticketmachine.core;
+package core;
 
 /**
  *

--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -22,7 +22,8 @@ public class TicketMachine {
     public void inserir(int quantia) throws PapelMoedaInvalidaException {
         boolean achou = false;
         for (int i = 0; i < papelMoeda.length && !achou; i++) {
-            if (papelMoeda[1] == quantia) {
+            // Ajuste das cédulas, que antes estava papelMoeda[1] e foi para papelMoeda[i], para verificar os restantes das cédulas
+            if (papelMoeda[i] == quantia) {
                 achou = true;
             }
         }

--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -1,7 +1,7 @@
-package br.calebe.ticketmachine.core;
+package core;
 
-import br.calebe.ticketmachine.exception.PapelMoedaInvalidaException;
-import br.calebe.ticketmachine.exception.SaldoInsuficienteException;
+import exception.PapelMoedaInvalidaException;
+import exception.SaldoInsuficienteException;
 import java.util.Iterator;
 
 /**

--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -1,4 +1,4 @@
-package br.calebe.ticketmachine.core;
+package core;
 
 import java.util.Iterator;
 

--- a/Source Code Inspection/src/br/calebe/ticketmachine/exception/PapelMoedaInvalidaException.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/exception/PapelMoedaInvalidaException.java
@@ -1,4 +1,4 @@
-package br.calebe.ticketmachine.exception;
+package exception;
 
 /**
  *

--- a/Source Code Inspection/src/br/calebe/ticketmachine/exception/SaldoInsuficienteException.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/exception/SaldoInsuficienteException.java
@@ -1,4 +1,4 @@
-package br.calebe.ticketmachine.exception;
+package exception;
 
 /**
  *


### PR DESCRIPTION
Nessa etapa foram corrigidos os issues de 1 a 5, que mostravam os erros de que as cédulas 2, 10,20,50,100 não eram aceitas na máquina.